### PR TITLE
Always execute extension, don't require @ColumnName

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ import com.gabrielittner.auto.value.cursor.ColumnName;
 }
 ```
 
-**Note**: Right now `createFromCursor()` is oly generated when at least one method is annotated with `@ColumnName`.
-
 Now build your project and create your Foo from a Cursor.
 
 ## Download

--- a/src/test/java/com/gabrielittner/auto/value/gson/AutoValueCursorExtensionTest.java
+++ b/src/test/java/com/gabrielittner/auto/value/gson/AutoValueCursorExtensionTest.java
@@ -12,87 +12,138 @@ import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
 public class AutoValueCursorExtensionTest {
 
-  @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
-            + "package test;\n"
-            + "import com.gabrielittner.auto.value.cursor.ColumnName;\n"
-            + "import com.google.auto.value.AutoValue;\n"
-            + "import javax.annotation.Nullable;\n"
-            + "@AutoValue public abstract class Test {\n"
-            // byte[] type
-            + "public abstract byte[] a();\n"
-            // double type
-            + "public abstract double b();\n"
-            // float type
-            + "public abstract float c();\n"
-            // int type
-            + "public abstract int d();\n"
-            // long type
-            + "public abstract long e();\n"
-            // short type
-            + "public abstract short f();\n"
-            // boolean type
-            + "public abstract boolean g();\n"
-            // String type
-            + "public abstract String h();\n"
-            // ColumnName
-            + "@ColumnName(\"column_i\") public abstract String i();\n"
-            // Nullable unsupported value
-            + "@Nullable public abstract int[] j();\n"
-            + "}\n"
-    );
+    @Test public void simple() {
+        simpleTypeTest("", "String", "cursor.getString(cursor.getColumnIndexOrThrow(\"a\");");
+    }
 
-    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
-            + "package test;\n"
-            + "\n"
-            + "import android.database.Cursor;\n"
-            + "import java.lang.String;\n"
-            + "\n"
-            + "final class AutoValue_Test extends $AutoValue_Test {\n"
-            + "  AutoValue_Test(byte[] a, double b, float c, int d, long e, short f, boolean g, String h, String i, int[] j) {\n"
-            + "    super(a, b, c, d, e, f, g, h, i, j);\n"
-            + "  }\n"
-            + "\n"
-            + "  static Test createFromCursor(Cursor cursor) {\n"
-            + "    byte[] a = cursor.getBlob(cursor.getColumnIndexOrThrow(\"a\"));\n"
-            + "    double b = cursor.getDouble(cursor.getColumnIndexOrThrow(\"b\"));\n"
-            + "    float c = cursor.getFloat(cursor.getColumnIndexOrThrow(\"c\"));\n"
-            + "    int d = cursor.getInt(cursor.getColumnIndexOrThrow(\"d\"));\n"
-            + "    long e = cursor.getLong(cursor.getColumnIndexOrThrow(\"e\"));\n"
-            + "    short f = cursor.getShort(cursor.getColumnIndexOrThrow(\"f\"));\n"
-            + "    boolean g = cursor.getInt(cursor.getColumnIndexOrThrow(\"g\")) == 1;\n"
-            + "    String h = cursor.getString(cursor.getColumnIndexOrThrow(\"h\"));\n"
-            + "    String i = cursor.getString(cursor.getColumnIndexOrThrow(\"column_i\"));\n"
-            + "    int[] j = null;\n"
-            + "    return new AutoValue_Test(a, b, c, d, e, f, g, h, i, j);\n"
-            + "  }\n"
-            + "}"
-    );
+    @Test public void simpleWithNullable() {
+        simpleTypeTest("@Nullable ", "String", "cursor.getString(cursor.getColumnIndexOrThrow(\"a\");");
+    }
 
-    assertAbout(javaSources())
-        .that(Collections.singletonList(source))
-        .processedWith(new AutoValueProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expected);
-  }
+    @Test public void simpleWithColumnName() {
+        simpleTypeTest("@ColumnName(\"column_a\") ", "String", "cursor.getString(cursor.getColumnIndexOrThrow(\"column_a\");");
+    }
 
-  @Test public void failTest() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
-            + "package test;\n"
-            + "import com.gabrielittner.auto.value.cursor.ColumnName;\n"
-            + "import com.google.auto.value.AutoValue;\n"
-            + "@AutoValue public abstract class Test {\n"
-            // byte[] type
-            + "public abstract int[] a();\n"
-            // ColumnName
-            + "@ColumnName(\"column_i\") public abstract String b();\n"
-            + "}\n"
-    );
+    @Test public void simpleWithColumnNameAndNullable() {
+        simpleTypeTest("@ColumnName(\"column_a\") @Nullable ", "String",
+                "cursor.getString(cursor.getColumnIndexOrThrow(\"column_a\");");
+    }
 
-    assertAbout(javaSources())
-            .that(Collections.singletonList(source))
-            .processedWith(new AutoValueProcessor())
-            .failsToCompile();
-}
+    // will generate null field, but method will effectively always throw when executed
+    // TODO when there is an explicit opt-in this test should fail
+    @Test public void unsupported() {
+        simpleTypeTest("", "int[]", "null; // type can't be read from cursor");
+    }
+
+    // will generate null field
+    @Test public void unsupportedWithNullable() {
+        simpleTypeTest("@Nullable ", "int[]", "null; // type can't be read from cursor");
+    }
+
+    // will fail
+    @Test public void unsupportedWithColumnName() {
+        JavaFileObject source = getSource("@ColumnName(\"column_i\") public abstract int[] a();\n");
+
+        assertAbout(javaSources())
+                .that(Collections.singletonList(source))
+                .processedWith(new AutoValueProcessor())
+                .failsToCompile();
+    }
+
+    // will fail
+    @Test public void unsupportedWithColumnNameAndNullable() {
+        JavaFileObject source = getSource("@ColumnName(\"column_i\") @Nullable public abstract int[] a();\n");
+
+        assertAbout(javaSources())
+                .that(Collections.singletonList(source))
+                .processedWith(new AutoValueProcessor())
+                .failsToCompile();
+    }
+
+    // will fail
+    @Test public void unsupportedWithoutColumnName() {
+        JavaFileObject source = getSource("@ColumnName(\"column_i\") public abstract int a();\n"
+                + "  public abstract int[] b();\n");
+
+        assertAbout(javaSources())
+                .that(Collections.singletonList(source))
+                .processedWith(new AutoValueProcessor())
+                .failsToCompile();
+    }
+
+    // will generate null field
+    @Test public void unsupportedWithoutColumnNameAndWithNullable() {
+        JavaFileObject source = getSource("@ColumnName(\"column_i\") public abstract int a();\n"
+                + "  @Nullable public abstract int[] b();\n");
+
+        assertAbout(javaSources())
+                .that(Collections.singletonList(source))
+                .processedWith(new AutoValueProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test public void types() {
+        String[] types = {"byte[]", "double", "float", "int", "long", "short", "String", "boolean",
+                "byte[]", "double", "float", "int", "long", "short", "Boolean"};
+        String[] gets = {"Blob", "Double", "Float", "Int", "Long", "Short", "String", "Int",
+                "Blob", "Double", "Float", "Int", "Long", "Short", "Int"};
+        String[] suffixe = {"", "", "", "", "", "", "", " == 1", "", "", "", "", "", "", " == 1" };
+        for (int i = 0; i < types.length; i++) {
+            String type = types[i];
+            String get = gets[i];
+            String suffix = suffixe[i];
+            simpleTypeTest("", type, "cursor.get" + get + "(cursor.getColumnIndexOrThrow(\"a\"))" + suffix + ";");
+            simpleTypeTest("@Nullable ", type, "cursor.get" + get + "(cursor.getColumnIndexOrThrow(\"a\"))" + suffix + ";");
+            simpleTypeTest("@ColumnName(\"column_a\") ", type, "cursor.get" + get + "(cursor.getColumnIndexOrThrow(\"column_a\"))" + suffix + ";");
+            simpleTypeTest("@ColumnName(\"column_a\") @Nullable ", type, "cursor.get" + get + "(cursor.getColumnIndexOrThrow(\"column_a\"))" + suffix + ";");
+        }
+    }
+
+    private static void simpleTypeTest(String annotation, String type, String cursorGet) {
+        String fields = annotation + "public abstract " + type + " a();\n";
+        JavaFileObject source = getSource(fields);
+
+        String constructorArgs = type + " a";
+        String constructorSuperArgs = "a";
+        String mapping = type + " a = " + cursorGet;
+        JavaFileObject expected = getExpected(constructorArgs, constructorSuperArgs, mapping);
+
+        assertAbout(javaSources()).that(Collections.singletonList(source))
+                .processedWith(new AutoValueProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(expected);
+    }
+
+    private static JavaFileObject getSource(String fields) {
+        return JavaFileObjects.forSourceString("test.Test", ""
+                        + "package test;\n"
+                        + "import com.gabrielittner.auto.value.cursor.ColumnName;\n"
+                        + "import com.google.auto.value.AutoValue;\n"
+                        + "import javax.annotation.Nullable;\n"
+                        + "@AutoValue public abstract class Test {\n"
+                        + "  " + fields
+                        + "}\n"
+        );
+    }
+
+    private static JavaFileObject getExpected(String constructorArgs, String constructorSuperArgs,
+            String mapping) {
+        return JavaFileObjects.forSourceString("test/AutoValue_Test", ""
+                        + "package test;\n"
+                        + "\n"
+                        + "import android.database.Cursor;\n"
+                        + "\n"
+                        + "final class AutoValue_Test extends $AutoValue_Test {\n"
+                        + "  AutoValue_Test(" + constructorArgs + ") {\n"
+                        + "    super(" + constructorSuperArgs + ");\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  static Test createFromCursor(Cursor cursor) {\n"
+                        + "    " + mapping + "\n"
+                        + "    return new AutoValue_Test(" + constructorSuperArgs + ");\n"
+                        + "  }\n"
+                        + "}"
+        );
+    };
 }


### PR DESCRIPTION
This change will always apply the extension, even if there is no `@ColumnName` or there are unsupported properties. 