### PR TITLE
AutoValue 1.3-rc1

### DIFF
--- a/auto-value-cursor/src/main/java/com/gabrielittner/auto/value/contentvalues/AutoValueContentValuesExtension.java
+++ b/auto-value-cursor/src/main/java/com/gabrielittner/auto/value/contentvalues/AutoValueContentValuesExtension.java
@@ -2,26 +2,20 @@ package com.gabrielittner.auto.value.contentvalues;
 
 import com.gabrielittner.auto.value.ColumnProperty;
 import com.gabrielittner.auto.value.util.Property;
-import com.google.auto.common.MoreElements;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 
 import static com.gabrielittner.auto.value.cursor.AutoValueCursorExtension.addColumnAdaptersToMethod;
 import static com.gabrielittner.auto.value.cursor.AutoValueCursorExtension.getColumnAdapters;
@@ -36,38 +30,26 @@ public class AutoValueContentValuesExtension extends AutoValueExtension {
     private static final ClassName CONTENT_VALUES =
             ClassName.get("android.content", "ContentValues");
 
-    private Set<ExecutableElement> methods(Context context) {
-        //TODO AutoValue 1.3: replace with context.getAbstractMethods()
-        Elements elements = context.processingEnvironment().getElementUtils();
-        TypeElement valueClass = context.autoValueClass();
-        return MoreElements.getLocalAndInheritedMethods(valueClass, elements);
-    }
-
     @Override
     public boolean applicable(Context context) {
-        return getMatchingAbstractMethod(methods(context), CONTENT_VALUES).isPresent();
+        return getMatchingAbstractMethod(context.abstractMethods(), CONTENT_VALUES).isPresent();
     }
 
     @Override
-    public Set<String> consumeProperties(Context context) {
+    public Set<ExecutableElement> consumeMethods(Context context) {
         Optional<ExecutableElement> method =
-                getMatchingAbstractMethod(methods(context), CONTENT_VALUES);
+                getMatchingAbstractMethod(context.abstractMethods(), CONTENT_VALUES);
         if (method.isPresent()) {
-            for (Map.Entry<String, ExecutableElement> element : context.properties().entrySet()) {
-                if (element.getValue().equals(method.get())) {
-                    String methodName = method.get().getSimpleName().toString();
-                    return ImmutableSet.copyOf(Arrays.asList(methodName, element.getKey()));
-                }
-            }
+            return Collections.singleton(method.get());
         }
         return Collections.emptySet();
     }
 
     @Override
     public String generateClass(
-            Context context, String className, String classToExtend, boolean isFinal) {
+            Context context, String className, String classToExtend,boolean isFinal) {
         Optional<ExecutableElement> method =
-                getMatchingAbstractMethod(methods(context), CONTENT_VALUES);
+                getMatchingAbstractMethod(context.abstractMethods(), CONTENT_VALUES);
         if (!method.isPresent()) throw new AssertionError("Method is null");
         ImmutableList<ColumnProperty> properties = ColumnProperty.from(context);
 

--- a/auto-value-cursor/src/test/java/com/gabrielittner/auto/value/contentvalues/AutoValueContentValuesExtensionTest.java
+++ b/auto-value-cursor/src/test/java/com/gabrielittner/auto/value/contentvalues/AutoValueContentValuesExtensionTest.java
@@ -306,7 +306,7 @@ public class AutoValueContentValuesExtensionTest {
                 + "@AutoValue public abstract class Test {\n"
                 + "  public abstract int getA();\n"
                 + "  public abstract String getB();\n"
-                + "  public abstract ContentValues getContentValues();\n"
+                + "  public abstract ContentValues toContentValues();\n"
                 + "}\n");
 
         JavaFileObject expected = JavaFileObjects.forSourceString("test.AutoValue_Test", ""
@@ -319,7 +319,7 @@ public class AutoValueContentValuesExtensionTest {
                 + "    super(a, b);\n"
                 + "  }\n"
                 + "  @Override\n"
-                + "  public ContentValues getContentValues() {\n"
+                + "  public ContentValues toContentValues() {\n"
                 + "    ContentValues values = new ContentValues(2);\n"
                 + "    values.put(\"a\", getA());\n"
                 + "    values.put(\"b\", getB());\n"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ ext {
 
 ext.deps = [
         javapoet: 'com.squareup:javapoet:1.7.0',
-        auto_value: 'com.google.auto.value:auto-value:1.2',
+        auto_value: 'com.google.auto.value:auto-value:1.3-rc1',
         auto_common: 'com.google.auto:auto-common:0.6',
         auto_ext_util: 'com.gabrielittner.auto.value:auto-value-extension-util:0.2.1',
 


### PR DESCRIPTION
changes in Cursor extension:
- none

changes in ContentValues extension:
- remove workaround for https://github.com/google/auto/issues/327 (**was breaking 1.3**)
- use `consumeMethods(Context)` instead of  `consumeProperties(Context)`
- use new `Context.abstractMethods()` instead of searching them manually
